### PR TITLE
ValueError: Invalid integer data type 'f'.

### DIFF
--- a/sewar/full_ref.py
+++ b/sewar/full_ref.py
@@ -62,7 +62,7 @@ def psnr (GT,P,MAX=None):
 	:returns:  float -- psnr value in dB.
 	"""
 	if MAX is None:
-		MAX = np.iinfo(GT.dtype).max
+		MAX = np.finfo(GT.dtype).max
 
 	GT,P = _initial_check(GT,P)
 


### PR DESCRIPTION
https://github.com/andrewekhalel/sewar/blob/ac76e7bc75732fde40bb0d3908f4b6863400cc27/sewar/full_ref.py#L65

`np.iinfo()` does not work with float data-type as input and raises error: `ValueError: Invalid integer data type 'f'`. Therefore, use `np.finfo()` instead.

For reference, check the Numpy Github link: https://github.com/numpy/numpy/issues/14400