### PR TITLE
Fix divide-by-zero in rase() for zero-mean reference images

### DIFF
--- a/sewar/full_ref.py
+++ b/sewar/full_ref.py
@@ -239,7 +239,11 @@ def rase(GT,P,ws=8):
 
 	N = GT.shape[2]
 	M = np.sum(GT_means,axis=2)/N
-	rase_map = (100./M) * np.sqrt( np.sum(rmse_map**2,axis=2) / N )
+
+	with np.errstate(divide='ignore', invalid='ignore'):
+		rase_map = np.where(M != 0,
+		                    (100./M) * np.sqrt(np.sum(rmse_map**2, axis=2) / N),
+		                    0.0)
 
 	s = int(np.round(ws/2))
 	return np.mean(rase_map[s:-s,s:-s])

--- a/sewar/tests/test_sewar.py
+++ b/sewar/tests/test_sewar.py
@@ -138,6 +138,25 @@ class TestRase(Tester):
 		rase = sewar.rase(self.read('gry'),self.read('gry'))
 		self.assertTrue(rase == 0)
 
+	def test_zero_gt_no_division_by_zero(self):
+		# When GT has zero mean, the old code divided by zero producing NaN/inf.
+		# The fix should return 0.0 for those windows instead.
+		gt = np.zeros((64, 64, 3), dtype=np.uint8)
+		p = np.full((64, 64, 3), 128, dtype=np.uint8)
+		result = sewar.rase(gt, p)
+		self.assertFalse(np.isnan(result), "rase returned NaN for zero-mean GT")
+		self.assertFalse(np.isinf(result), "rase returned inf for zero-mean GT")
+		self.assertEqual(result, 0.0)
+
+	def test_partial_zero_gt_is_finite(self):
+		# GT where only part of the image has zero mean — result must be finite.
+		gt = np.zeros((64, 64, 3), dtype=np.uint8)
+		gt[32:, 32:, :] = 100
+		p = np.full((64, 64, 3), 128, dtype=np.uint8)
+		result = sewar.rase(gt, p)
+		self.assertFalse(np.isnan(result), "rase returned NaN for partial zero-mean GT")
+		self.assertFalse(np.isinf(result), "rase returned inf for partial zero-mean GT")
+
 class TestSam(Tester):
 	def test_color(self):
 		sam = sewar.sam(self.read('clr'),self.read('clr'))


### PR DESCRIPTION
## Summary
- `rase()` raised a `RuntimeWarning: divide by zero` (and produced `inf` values) when the reference image had zero-mean bands (e.g. a fully black image or a band with all-zero pixels)
- Fixed by using `np.where` to set `rase_map` to `0.0` at pixels where `M == 0`, suppressing the numpy warning with `np.errstate`

## Test plan
- [ ] Verify `sewar.rase(img, img)` still returns `0.0`
- [ ] Verify `sewar.rase(np.zeros(...), non_zero_img)` no longer crashes or warns

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)