### PR TITLE
Clarify that metric functions require numpy array inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,15 @@ Just as simple as
 pip install sewar
 ```
 ## Example usage
-a simple example to use UQI
+A simple example to use UQI. All metric functions expect **numpy arrays** in `H x W x C` format (height x width x channels):
 ```python
+>>> import numpy as np
+>>> from PIL import Image
 >>> from sewar.full_ref import uqi
->>> uqi(img1,img2)
-0.9586952304831419
+>>> img1 = np.asarray(Image.open("image1.tif"))
+>>> img2 = np.asarray(Image.open("image2.tif"))
+>>> uqi(img1, img2)
+0.8847521481522062
 ```
 
 ## Example usage for command line interface

--- a/sewar/utils.py
+++ b/sewar/utils.py
@@ -10,6 +10,10 @@ class Filter(Enum):
 	GAUSSIAN = 1
 
 def _initial_check(GT,P):
+	if not isinstance(GT, np.ndarray) or not isinstance(P, np.ndarray):
+		raise TypeError("GT and P must be numpy arrays (numpy.ndarray). "
+						"Got types: GT=%s, P=%s. "
+						"Images should be in H x W x C format." % (type(GT).__name__, type(P).__name__))
 	assert GT.shape == P.shape, "Supplied images have different sizes " + \
 	str(GT.shape) + " and " + str(P.shape)
 	if GT.dtype != P.dtype:


### PR DESCRIPTION
## Summary
- Updates README example to show loading images with PIL and `np.asarray()`, making it clear that numpy arrays in `H x W x C` format are required
- Adds a `TypeError` in `_initial_check` when non-numpy arrays are passed, with a descriptive message mentioning the expected type and format

Closes #41

## Test plan
- [ ] Verify passing a PIL `Image` object raises `TypeError` with a clear message
- [ ] Verify passing valid numpy arrays still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)