### PR TITLE
Fix msssim crash on wide/tall images (issue #37)

### DIFF
--- a/sewar/full_ref.py
+++ b/sewar/full_ref.py
@@ -297,6 +297,20 @@ def msssim (GT,P,weights = [0.0448, 0.2856, 0.3001, 0.2363, 0.1333],ws=11,K1=0.0
 	if isinstance(weights, list):
 		weights = np.array(weights)
 
+	# Cap scales so the image is never smaller than the filter window after downsampling.
+	# After k halvings the short side is min_dim/2^k; we need that >= ws.
+	min_dim = min(GT.shape[0], GT.shape[1])
+	max_scales = int(np.floor(np.log2(min_dim / ws))) + 1
+	if scales > max_scales:
+		import warnings
+		warnings.warn(
+			"Image is too small for {} scales with window size {}. "
+			"Reducing to {} scales.".format(scales, ws, max_scales),
+			UserWarning
+		)
+		scales = max_scales
+		weights = weights[:scales]
+
 	mssim = []
 	mcs = []
 	for _ in range(scales):

--- a/sewar/tests/test_sewar.py
+++ b/sewar/tests/test_sewar.py
@@ -180,6 +180,20 @@ class TestMsssim(Tester):
 		print (msssim)
 		self.assertTrue(abs(0.631429952770791-msssim)<self.eps)
 
+	def test_wide_image(self):
+		# Regression for issue #37: wide images crashed because downsampling
+		# reduced the short side below the filter window size.
+		rng = np.random.default_rng(0)
+		a = rng.integers(0, 256, (90, 1920, 3), dtype=np.uint8)
+		b = rng.integers(0, 256, (90, 1920, 3), dtype=np.uint8)
+		import warnings
+		with warnings.catch_warnings(record=True) as w:
+			warnings.simplefilter('always')
+			result = sewar.msssim(a, b)
+			self.assertEqual(len(w), 1)
+			self.assertIn('Reducing to', str(w[0].message))
+		self.assertTrue(np.isfinite(result.real))
+
 class TestNoRef(Tester):
 	def test_color(self):
 		d = sewar.no_ref.d_lambda(self.read('clr'),self.read('clr'))


### PR DESCRIPTION
## Summary

- `msssim` repeatedly downsamples images at each scale level; for images with a short side < `ws * 2^(scales-1)`, that dimension eventually drops below the filter window size and `scipy.signal.convolve2d` raises `ValueError` in `valid` mode
- Cap `scales` to `floor(log2(min_dim / ws)) + 1` before the loop, truncate `weights` to match, and emit a `UserWarning` when the count is reduced
- Adds a regression test using the exact shape from the issue report (`90×1920×3`)

## Test plan

- [ ] `test_wide_image` reproduces the crash with shape `(90, 1920, 3)` and verifies it now completes with a warning and a finite result
- [ ] Existing `TestMsssim` tests (`test_color`, `test_gray`, `test_against_matlab`) continue to pass unchanged on 512×512 images

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)